### PR TITLE
Enhance media fetching and transformation functionality

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,6 +27,15 @@
             "program": "${workspaceFolder}",
             "args": ["--manual-token", "--fetch-and-transform-media", "--media-dir", "${workspaceFolder}/output/media", "--output", "${workspaceFolder}/output"],
             "envFile": "${workspaceFolder}/.env"
+        },
+        {
+            "name": "Fetch and Transform Media",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}",
+            "args": ["--fetch-and-transform-media", "--json-file", "${workspaceFolder}/output/recent_media.json", "--media-dir", "${workspaceFolder}/output/media", "--output", "${workspaceFolder}/output"],
+            "envFile": "${workspaceFolder}/.env"
         }
     ]
 }

--- a/mediaconversion.go
+++ b/mediaconversion.go
@@ -440,9 +440,9 @@ func WriteMediaInfoJSON(allConvertedFiles []ConvertedFileInfo, outputDir string)
 		fmt.Printf("Error creating output directory: %v\n", err)
 		return
 	}
-	
+
 	// Write the JSON file
-	mediaInfoPath := filepath.Join(outputDir, "media_info.json")
+	mediaInfoPath := filepath.Join(outputDir, "converted_media.json")
 	mediaInfoJSON, err := json.MarshalIndent(mediaFilesArray, "", "  ")
 	if err != nil {
 		fmt.Printf("Error creating JSON: %v\n", err)


### PR DESCRIPTION
- Added a new command line flag `--fetch-and-transform-media` to allow fetching and transforming media from a specified JSON file.
- Implemented logic to read media data from a JSON file and handle errors appropriately.
- Updated the output file name for media information from `media_info.json` to `converted_media.json`.
- Enhanced VSCode launch configuration to include a new setup for fetching and transforming media.