### PR TITLE
It's a little insane to me that Go doesn't support iso8601 out of the box...

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,7 +25,7 @@
             "request": "launch",
             "mode": "auto",
             "program": "${workspaceFolder}",
-            "args": ["--manual-token", "--fetch-and-transform-media", "--media-dir", "${workspaceFolder}/output/media", "--output", "${workspaceFolder}/output"],
+            "args": ["--manual-token", "--fetch-and-transform-media", "--media-dir", "${workspaceFolder}/output/media", "--output-dir", "${workspaceFolder}/output"],
             "envFile": "${workspaceFolder}/.env"
         },
         {

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
+	github.com/relvacode/iso8601 v1.6.0
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	golang.org/x/arch v0.16.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNH
 github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/relvacode/iso8601 v1.6.0 h1:eFXUhMJN3Gz8Rcq82f9DTMW0svjtAVuIEULglM7QHTU=
+github.com/relvacode/iso8601 v1.6.0/go.mod h1:FlNp+jz+TXpyRqgmM7tnzHHzBnz776kmAH2h3sZCn0I=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/mediaconversion.go
+++ b/mediaconversion.go
@@ -17,6 +17,7 @@ import (
 	"github.com/disintegration/imaging"
 	"github.com/kolesa-team/go-webp/encoder"
 	"github.com/kolesa-team/go-webp/webp"
+	"github.com/relvacode/iso8601"
 )
 
 // MediaFileVersionEntry represents information about a converted file
@@ -308,6 +309,22 @@ func FetchAndTransformMedia(recentMedia []Media, mediaDir string, outputDir stri
 	for entry := range resultChan {
 		mediaFilesArray = append(mediaFilesArray, entry)
 	}
+
+	// sort mediaFilesArray by timestamp
+	sort.Slice(mediaFilesArray, func(i, j int) bool {
+		// converrt timestamp to int
+		// timestamp is in format 2025-04-16T15:58:54+0000
+		timestampI, err := iso8601.ParseString(mediaFilesArray[i].Timestamp)
+		if err != nil {
+			return false
+		}
+		timestampJ, err := iso8601.ParseString(mediaFilesArray[j].Timestamp)
+		if err != nil {
+			return false
+		}
+
+		return timestampI.After(timestampJ)
+	})
 
 	// Update the counts
 	skippedCount := int(skippedCountAtomic)


### PR DESCRIPTION
- Added `github.com/relvacode/iso8601` as a dependency in `go.mod` and `go.sum`.
- Implemented sorting of media files by timestamp in the `FetchAndTransformMedia` function using the new iso8601 package for parsing timestamps.