### PR TITLE
Add GitHub workflow for dispatching dependent workflows and update media file structure

### DIFF
--- a/.github/workflows/dispatch-dependent-workflows.yml
+++ b/.github/workflows/dispatch-dependent-workflows.yml
@@ -1,0 +1,19 @@
+name: Dispatch Dependent Workflows
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+
+run-name: "Dispatch Dependent Workflows"
+
+jobs:
+  dispatch_event:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Event to Dependent Repo
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: '${{ secrets.DEPENDENT_REPO_TOKEN }}'
+          repository: '${{ secrets.DEPENDENT_REPO }}'
+          event-type: 'Instagram-Recents-Go Main Updated'

--- a/lib/mediaconversion.go
+++ b/lib/mediaconversion.go
@@ -31,6 +31,7 @@ type ImageVersionEntry struct {
 type MediaFileEntry struct {
 	MediaID   string                       `json:"media_id"`
 	Timestamp string                       `json:"timestamp"`
+	Permalink string                       `json:"permalink"`
 	Versions  map[string]ImageVersionEntry `json:"versions"`
 }
 
@@ -248,6 +249,7 @@ func FetchAndTransformImages(recentMedia []Media, mediaDir string, outputDir str
 			resultChan <- MediaFileEntry{
 				MediaID:   media.ID,
 				Timestamp: media.Timestamp,
+				Permalink: media.Permalink,
 				Versions:  versionMap,
 			}
 			atomic.AddInt32(&processedCountAtomic, 1)


### PR DESCRIPTION
- Created a new workflow to dispatch events to a dependent repository on push to the main branch or manual trigger.
- Added a `Permalink` field to the `MediaFileEntry` struct to include media links in the processing logic.