### PR TITLE
Update GitHub workflow for dispatching dependent workflows

### DIFF
--- a/.github/workflows/dispatch-dependent-workflows.yml
+++ b/.github/workflows/dispatch-dependent-workflows.yml
@@ -1,9 +1,5 @@
 name: Dispatch Dependent Workflows
-on:
-  workflow_dispatch:
-  push:
-    branches:
-      - 'main'
+on: [workflow_dispatch, push]
 
 run-name: "Dispatch Dependent Workflows"
 
@@ -16,4 +12,5 @@ jobs:
         with:
           token: '${{ secrets.DEPENDENT_REPO_TOKEN }}'
           repository: '${{ secrets.DEPENDENT_REPO }}'
-          event-type: 'Instagram-Recents-Go Main Updated'
+          event-type: 'instagram-recents-go-commit'
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "repo": "${{ github.repository }}"}'


### PR DESCRIPTION
- Simplified event triggers to use a single line for `workflow_dispatch` and `push`.
- Changed the event type to 'instagram-recents-go-commit' and added a client payload for better context in dispatched events.