### PR TITLE
Ignore built binary instagram-recents-go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 *.so
 *.dylib
 
+# Built binary (go build -o instagram-recents-go)
+instagram-recents-go
+
 # Test binary, built with `go test -c`
 *.test
 


### PR DESCRIPTION
Adds the built binary `instagram-recents-go` to `.gitignore` so `go build -o instagram-recents-go` does not leave an untracked file in the repo. Parent repo (chaotic.dog) now builds to `output/instagram-recents-go`; this keeps the root binary ignored for local or alternate builds.