### PR TITLE
Add .gomodcache and .gocache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,10 @@ instagram-recents-go
 # Output directory
 output/
 
+# CI cache dirs (populated by GitHub Actions)
+.gomodcache/
+.gocache/
+
 # Dependency directories (remove the comment below to include it)
 # vendor/
 


### PR DESCRIPTION
The parent repo (chaotic.dog) caches Go module and build output in `instagram-recents-go/.gomodcache` and `instagram-recents-go/.gocache` during CI. This PR adds those paths to `.gitignore` so the cache dirs are not committed.