### PR TITLE
Configure CodeRabbit reviews for all base branches

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,6 @@
+reviews:
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - ".*"


### PR DESCRIPTION
Configure CodeRabbit auto-review so PRs targeting stacked or non-default branches are reviewed automatically. Draft PR reviews remain disabled.